### PR TITLE
Add scrubbers

### DIFF
--- a/nameko_opentelemetry/__init__.py
+++ b/nameko_opentelemetry/__init__.py
@@ -2,7 +2,7 @@
 from opentelemetry import trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 
-from nameko_opentelemetry import entrypoints, events, http, messaging, rpc
+from nameko_opentelemetry import amqp, entrypoints, events, http, messaging, rpc
 from nameko_opentelemetry.package import _instruments
 from nameko_opentelemetry.version import __version__
 
@@ -28,6 +28,7 @@ class NamekoInstrumentor(BaseInstrumentor):
 
         entrypoints.instrument(tracer, config)
         http.instrument(tracer, config)
+        amqp.instrument(tracer, config)
         rpc.instrument(tracer, config)
         events.instrument(tracer, config)
         messaging.instrument(tracer, config)
@@ -35,6 +36,7 @@ class NamekoInstrumentor(BaseInstrumentor):
     def _uninstrument(self, **kwargs):
         entrypoints.uninstrument()
         http.uninstrument()
+        amqp.uninstrument()
         rpc.uninstrument()
         events.uninstrument()
         messaging.uninstrument()

--- a/nameko_opentelemetry/amqp.py
+++ b/nameko_opentelemetry/amqp.py
@@ -61,7 +61,7 @@ def amqp_publisher_attributes(publisher, kwargs, config):
         f"{PREFIX}.routing_key": get_routing_key(publisher, kwargs),
     }
 
-    if config.get("send_headers"):
+    if config.get("send_headers"):  # pragma: no cover (temporary; module needs tests)
         attributes.update({f"{PREFIX}.headers": get_headers(publisher, kwargs, config)})
 
     return attributes

--- a/nameko_opentelemetry/amqp.py
+++ b/nameko_opentelemetry/amqp.py
@@ -2,6 +2,7 @@
 """ Utility functions that extract relevant attributes from AMQP
 publishers and consumers.
 """
+from nameko_opentelemetry.scrubbers import scrub
 from nameko_opentelemetry.utils import serialise_to_string
 
 
@@ -18,7 +19,7 @@ def get_routing_key(publisher, kwargs):
     return serialise_to_string(options.get("routing_key"))
 
 
-def get_headers(publisher, kwargs):
+def get_headers(publisher, kwargs, config):
     """
     Extract final headers included in the published message. Must be extracted
     from several combined sources.
@@ -26,10 +27,10 @@ def get_headers(publisher, kwargs):
     headers = publisher.publish_kwargs.get("headers", {})
     headers.update(kwargs.get("headers", {}))
     headers.update(kwargs.get("extra_headers", {}))
-    return serialise_to_string(headers)
+    return serialise_to_string(scrub(headers, config))
 
 
-def amqp_publisher_attributes(publisher, kwargs):
+def amqp_publisher_attributes(publisher, kwargs, config):
     """
     Extract attributes relevant to AMQP message publishers.
 
@@ -42,7 +43,7 @@ def amqp_publisher_attributes(publisher, kwargs):
             kwargs.get(attribute, getattr(publisher, attribute, None))
         )
 
-    return {
+    attributes = {
         f"{PREFIX}.amqp_uri": generic_getter("amqp_uri"),
         f"{PREFIX}.ssl": generic_getter("ssl"),
         f"{PREFIX}.use_confirms": generic_getter("use_confirms"),
@@ -58,8 +59,12 @@ def amqp_publisher_attributes(publisher, kwargs):
         f"{PREFIX}.transport_options": generic_getter("transport_options"),
         f"{PREFIX}.publish_kwargs": generic_getter("publish_kwargs"),
         f"{PREFIX}.routing_key": get_routing_key(publisher, kwargs),
-        f"{PREFIX}.headers": get_headers(publisher, kwargs),
     }
+
+    if config.get("send_headers"):
+        attributes.update({f"{PREFIX}.headers": get_headers(publisher, kwargs, config)})
+
+    return attributes
 
 
 def amqp_consumer_attributes(consumer):

--- a/nameko_opentelemetry/entrypoints.py
+++ b/nameko_opentelemetry/entrypoints.py
@@ -232,6 +232,8 @@ def worker_setup(tracer, config, wrapped, instance, args, kwargs):
 
     adapter.start_span(span)
 
+    wrapped(*args, **kwargs)
+
 
 def worker_result(tracer, config, wrapped, instance, args, kwargs):
     """ Wrap nameko.containers.ServiceContainer._worker_result.
@@ -259,6 +261,8 @@ def worker_result(tracer, config, wrapped, instance, args, kwargs):
     span.end(_time_ns())
     context.detach(token)
 
+    wrapped(*args, **kwargs)
+
 
 def instrument(tracer, config):
 
@@ -285,5 +289,5 @@ def instrument(tracer, config):
 
 
 def uninstrument():
-    unwrap(nameko.containers.ServiceContainer, "worker_setup")
-    unwrap(nameko.containers.ServiceContainer, "worker_result")
+    unwrap(nameko.containers.ServiceContainer, "_worker_setup")
+    unwrap(nameko.containers.ServiceContainer, "_worker_result")

--- a/nameko_opentelemetry/entrypoints.py
+++ b/nameko_opentelemetry/entrypoints.py
@@ -36,6 +36,7 @@ from opentelemetry.util._time import _time_ns
 from wrapt import wrap_function_wrapper
 
 from nameko_opentelemetry import utils
+from nameko_opentelemetry.scrubbers import scrub
 
 
 DEFAULT_ADAPTERS = {
@@ -118,8 +119,8 @@ class EntrypointAdapter:
             attributes.update(
                 {
                     "context_data": utils.serialise_to_string(
-                        self.worker_ctx.data
-                    ),  # TODO scrub!
+                        scrub(self.worker_ctx.data, self.config)
+                    )
                 }
             )
 
@@ -141,7 +142,7 @@ class EntrypointAdapter:
                 redacted = False
 
             call_args, truncated = utils.truncate(
-                utils.serialise_to_string(call_args),
+                utils.serialise_to_string(scrub(call_args, self.config)),
                 max_len=self.config.get("truncate_max_length"),
             )
 
@@ -174,7 +175,10 @@ class EntrypointAdapter:
         """ Attributes describing the entrypoint method result.
         """
         if self.config.get("send_response_payloads"):
-            attributes = {"result": utils.safe_for_serialisation(result or "")}
+
+            attributes = {
+                "result": utils.serialise_to_string(scrub(result or "", self.config))
+            }
         else:
             attributes = {}
         return attributes

--- a/nameko_opentelemetry/events.py
+++ b/nameko_opentelemetry/events.py
@@ -14,10 +14,7 @@ from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.propagate import inject
 from wrapt import FunctionWrapper, wrap_function_wrapper
 
-from nameko_opentelemetry.amqp import (
-    amqp_consumer_attributes,
-    amqp_publisher_attributes,
-)
+from nameko_opentelemetry.amqp import amqp_consumer_attributes
 from nameko_opentelemetry.entrypoints import EntrypointAdapter
 from nameko_opentelemetry.scrubbers import scrub
 from nameko_opentelemetry.utils import (
@@ -71,7 +68,6 @@ def collect_client_attributes(
                 "nameko.events.event_data_truncated": str(truncated),
             }
         )
-    attributes.update(amqp_publisher_attributes(publisher, kwargs, config))
     return attributes
 
 

--- a/nameko_opentelemetry/events.py
+++ b/nameko_opentelemetry/events.py
@@ -19,6 +19,7 @@ from nameko_opentelemetry.amqp import (
     amqp_publisher_attributes,
 )
 from nameko_opentelemetry.entrypoints import EntrypointAdapter
+from nameko_opentelemetry.scrubbers import scrub
 from nameko_opentelemetry.utils import (
     call_function_get_frame,
     serialise_to_string,
@@ -61,7 +62,8 @@ def collect_client_attributes(
     }
     if config.get("send_request_payloads"):
         data, truncated = truncate(
-            serialise_to_string(event_data), max_len=config.get("truncate_max_length")
+            serialise_to_string(scrub(event_data, config)),
+            max_len=config.get("truncate_max_length"),
         )
         attributes.update(
             {
@@ -69,7 +71,7 @@ def collect_client_attributes(
                 "nameko.events.event_data_truncated": str(truncated),
             }
         )
-    attributes.update(amqp_publisher_attributes(publisher, kwargs))
+    attributes.update(amqp_publisher_attributes(publisher, kwargs, config))
     return attributes
 
 

--- a/nameko_opentelemetry/http.py
+++ b/nameko_opentelemetry/http.py
@@ -106,14 +106,13 @@ class HttpEntrypointAdapter(EntrypointAdapter):
         }
 
         if self.config.get("send_response_payloads"):
+
             response, truncated = utils.truncate(
-                result.get_data(), max_len=self.config.get("truncate_max_length")
+                scrub(result.get_data(), self.config),
+                max_len=self.config.get("truncate_max_length"),
             )
             attributes.update(
-                {
-                    "response.data": response,  # do we want to send this?
-                    "response.data_truncated": str(truncated),
-                }
+                {"response.data": response, "response.data_truncated": str(truncated)}
             )
 
         return attributes

--- a/nameko_opentelemetry/messaging.py
+++ b/nameko_opentelemetry/messaging.py
@@ -12,10 +12,7 @@ from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.propagate import inject
 from wrapt import FunctionWrapper, wrap_function_wrapper
 
-from nameko_opentelemetry.amqp import (
-    amqp_consumer_attributes,
-    amqp_publisher_attributes,
-)
+from nameko_opentelemetry.amqp import amqp_consumer_attributes
 from nameko_opentelemetry.entrypoints import EntrypointAdapter
 from nameko_opentelemetry.scrubbers import scrub
 from nameko_opentelemetry.utils import serialise_to_string, truncate
@@ -51,7 +48,6 @@ def get_dependency(tracer, config, wrapped, instance, args, kwargs):
     """
 
     (worker_ctx,) = args
-    publisher = instance
     exchange = instance.exchange
 
     def wrapped_publish(wrapped, instance, args, kwargs):
@@ -72,9 +68,6 @@ def get_dependency(tracer, config, wrapped, instance, args, kwargs):
                     "nameko.messaging.payload_truncated": str(truncated),
                 }
             )
-        attributes.update(
-            amqp_publisher_attributes(publisher.publisher, kwargs, config)
-        )
 
         with tracer.start_as_current_span(
             f"Publish to {target}", attributes=attributes, kind=trace.SpanKind.PRODUCER,

--- a/nameko_opentelemetry/rpc.py
+++ b/nameko_opentelemetry/rpc.py
@@ -46,12 +46,12 @@ class RpcEntrypointAdapter(EntrypointAdapter):
         return attributes
 
 
-def collect_client_attributes(target_service, target_method, publisher, kwargs):
+def collect_client_attributes(target_service, target_method, publisher, kwargs, config):
     attributes = {
         "nameko.rpc.target_service": target_service,
         "nameko.rpc.target_method": target_method,
     }
-    attributes.update(amqp_publisher_attributes(publisher, kwargs))
+    attributes.update(amqp_publisher_attributes(publisher, kwargs, config))
     return attributes
 
 
@@ -113,6 +113,7 @@ def initiate_call(tracer, config, wrapped, instance, args, kwargs):
             # XXX EXCLUDE if not send_headers (refactor to do publisher.publish first)
             "extra_headers": encode_to_headers(client.context_data),
         },
+        config,
     )
 
     span = tracer.start_span(

--- a/nameko_opentelemetry/rpc.py
+++ b/nameko_opentelemetry/rpc.py
@@ -50,6 +50,7 @@ def collect_client_attributes(target_service, target_method, publisher, kwargs, 
     attributes = {
         "nameko.rpc.target_service": target_service,
         "nameko.rpc.target_method": target_method,
+        # XXX send payload? probably should, for consistency w/ everything else
     }
     attributes.update(amqp_publisher_attributes(publisher, kwargs, config))
     return attributes

--- a/nameko_opentelemetry/scrubbers.py
+++ b/nameko_opentelemetry/scrubbers.py
@@ -85,13 +85,26 @@ class DefaultScrubber:
 
             return data
 
-        if isinstance(data, collections.abc.Iterable) and not isinstance(data, str):
+        if isinstance(data, collections.abc.Iterable) and not isinstance(
+            data, (str, bytes)
+        ):
             scrubbed = list(map(self.scrub, data))
             try:
                 return type(data)(scrubbed)
             except TypeError:
                 return list(scrubbed)
 
-        if self.sensitive_value(str(data)):
-            return self.REPLACEMENT
+        if isinstance(data, bytes):
+            try:
+                decoded = data.decode("utf-8")
+            except UnicodeDecodeError:
+                pass
+            else:
+                if self.sensitive_value(decoded):
+                    return self.REPLACEMENT.encode("utf-8")
+
+        if isinstance(data, str):
+            if self.sensitive_value(str(data)):
+                return self.REPLACEMENT
+
         return data

--- a/nameko_opentelemetry/scrubbers.py
+++ b/nameko_opentelemetry/scrubbers.py
@@ -70,6 +70,7 @@ class DefaultScrubber:
         """
         if isinstance(data, dict):
             data = data.copy()
+            replace_keys = {}
             for key, value in data.items():
                 if self.sensitive_key(key):
                     value = self.REPLACEMENT
@@ -77,10 +78,13 @@ class DefaultScrubber:
                     value = self.scrub(value)
 
                 if self.sensitive_value(key):
-                    del data[key]
-                    data[self.REPLACEMENT] = value
+                    replace_keys[key] = value
                 else:
                     data[key] = value
+
+            for key, value in replace_keys.items():
+                del data[key]
+                data[self.REPLACEMENT] = value
 
             return data
 

--- a/nameko_opentelemetry/scrubbers.py
+++ b/nameko_opentelemetry/scrubbers.py
@@ -87,6 +87,3 @@ class DefaultScrubber:
         if self.sensitive_value(str(data)):
             return self.REPLACEMENT
         return data
-
-
-# ??? start with usage.

--- a/nameko_opentelemetry/scrubbers.py
+++ b/nameko_opentelemetry/scrubbers.py
@@ -1,6 +1,8 @@
 import collections
 import re
 
+from nameko.constants import HEADER_PREFIX
+
 from nameko_opentelemetry.utils import import_by_path
 
 
@@ -40,6 +42,8 @@ class DefaultScrubber:
         "stripeToken",
     )
 
+    COMMON_KEY_PREFIXES = ("nameko.", "x-")
+
     SENSITIVE_VALUES = (
         re.compile(r"[a-z0-9._%\+\-—|]+@[a-z0-9.\-—|]+\.[a-z|]{2,6}"),  # email address
     )
@@ -50,6 +54,10 @@ class DefaultScrubber:
         self.config = config
 
     def sensitive_key(self, key):
+        for prefix in self.COMMON_KEY_PREFIXES:
+            if key.startswith(prefix):
+                chop = len(prefix)
+                key = key[chop:]
         return key in self.SENSITIVE_KEYS
 
     def sensitive_value(self, value):

--- a/nameko_opentelemetry/scrubbers.py
+++ b/nameko_opentelemetry/scrubbers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import collections
 import re
 

--- a/nameko_opentelemetry/scrubbers.py
+++ b/nameko_opentelemetry/scrubbers.py
@@ -60,7 +60,7 @@ class DefaultScrubber:
         return key in self.SENSITIVE_KEYS
 
     def sensitive_value(self, value):
-        for regex in self.SENSITIVE_VALUES:
+        for regex in self.SENSITIVE_VALUES:  # pragma: no cover (branch to exit)
             return regex.match(value)
 
     def scrub(self, data):

--- a/nameko_opentelemetry/scrubbers.py
+++ b/nameko_opentelemetry/scrubbers.py
@@ -1,0 +1,92 @@
+import collections
+import re
+
+from nameko_opentelemetry.utils import import_by_path
+
+
+SCRUBBED = "scrubbed"
+
+
+def scrubbers(config):
+    for scrubber_path in config.get(
+        "scrubbers", ["nameko_opentelemetry.scrubbers.DefaultScrubber"]
+    ):
+        scrubber_cls = import_by_path(scrubber_path)
+        yield scrubber_cls(config)
+
+
+def scrub(data, config):
+    for scrubber in scrubbers(config):
+        data = scrubber.scrub(data)
+    return data
+
+
+class DefaultScrubber:
+
+    SENSITIVE_KEYS = (
+        "token",
+        "password",
+        "jwt",
+        "auth",
+        "password",
+        "secret",
+        "passwd",
+        "api_key",
+        "apikey",
+        "access_token",
+        "auth",
+        "credentials",
+        "mysql_pwd",
+        "stripeToken",
+    )
+
+    SENSITIVE_VALUES = (
+        re.compile(r"[a-z0-9._%\+\-—|]+@[a-z0-9.\-—|]+\.[a-z|]{2,6}"),  # email address
+    )
+
+    REPLACEMENT = SCRUBBED
+
+    def __init__(self, config):
+        self.config = config
+
+    def sensitive_key(self, key):
+        return key in self.SENSITIVE_KEYS
+
+    def sensitive_value(self, value):
+        for regex in self.SENSITIVE_VALUES:
+            return regex.match(value)
+
+    def scrub(self, data):
+        """ `data` can be a dict, an iterable, or a scalar value.
+
+        Returns a scubbed version and leaves original unchanged.
+        """
+        if isinstance(data, dict):
+            data = data.copy()
+            for key, value in data.items():
+                if self.sensitive_key(key):
+                    value = self.REPLACEMENT
+                else:
+                    value = self.scrub(value)
+
+                if self.sensitive_value(key):
+                    del data[key]
+                    data[self.REPLACEMENT] = value
+                else:
+                    data[key] = value
+
+            return data
+
+        if isinstance(data, collections.abc.Iterable) and not isinstance(data, str):
+            scrubbed = list(map(self.scrub, data))
+            try:
+                return type(data)(scrubbed)
+            except TypeError:
+                return list(scrubbed)
+
+        if self.sensitive_value(str(data)):
+            return self.REPLACEMENT
+        return data
+
+
+# ??? start with usage.

--- a/nameko_opentelemetry/scrubbers.py
+++ b/nameko_opentelemetry/scrubbers.py
@@ -1,8 +1,6 @@
 import collections
 import re
 
-from nameko.constants import HEADER_PREFIX
-
 from nameko_opentelemetry.utils import import_by_path
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,38 @@
 # -*- coding: utf-8 -*-
 import pytest
 from opentelemetry import trace
+from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from wrapt import wrap_function_wrapper
 
 from nameko_opentelemetry import NamekoInstrumentor
 
 
 @pytest.fixture(scope="session")
-def memory_exporter():
+def filter_spans():
+    def filter_rabbit(span):
+        if "api/vhosts/nameko_test" not in span.attributes.get(
+            "http.url", ""
+        ):  # pragma: no cover (don't cover false branch)
+            return True
+
+    def get_finished_spans(wrapped, instance, args, kwargs):
+        spans = wrapped(*args, **kwargs)
+        return list(filter(filter_rabbit, spans))
+
+    wrap_function_wrapper(
+        "opentelemetry.sdk.trace.export.in_memory_span_exporter",
+        "InMemorySpanExporter.get_finished_spans",
+        get_finished_spans,
+    )
+    yield
+    unwrap(InMemorySpanExporter, "get_finished_spans")
+
+
+@pytest.fixture(scope="session")
+def memory_exporter(filter_spans):
     return InMemorySpanExporter()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,6 @@ def config():
         "send_response_payloads": True,
         "send_context_data": True,  # XXX?
         "truncate_max_length": 200,
-        "scrubbers": ["a class reference", "another class reference"],
     }
 
 

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+# test add to active span
+# test no active span
+
+import ast
+
+import nameko
+import pytest
+from nameko.amqp.consume import Consumer
+from nameko.amqp.publish import Publisher
+
+from nameko_opentelemetry import active_tracer
+from nameko_opentelemetry.amqp import amqp_consumer_attributes
+
+
+class TestAddToActiveSpan:
+    @pytest.fixture
+    def publisher(self, rabbit_config):
+        return Publisher(amqp_uri=nameko.config["AMQP_URI"], use_confirms=True)
+
+    def test_no_active_span(self, publisher, memory_exporter):
+        publisher.publish("msg")
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 0
+
+    def test_active_span(self, publisher, rabbit_config, memory_exporter):
+        with active_tracer().start_as_current_span("foobar", attributes={"foo": "bar"}):
+            publisher.publish("msg")
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+
+        assert spans[0].name == "foobar"
+        assert spans[0].attributes["nameko.amqp.amqp_uri"] == nameko.config["AMQP_URI"]
+
+
+class TestPublisherAttributes:
+    @pytest.fixture
+    def publisher(self, rabbit_config):
+        return Publisher(
+            amqp_uri=nameko.config["AMQP_URI"],
+            routing_key="foo",
+            headers={
+                "header-1": "value-1",
+                "header-2": "value-2",
+                "header-3": "value-3",
+            },
+        )
+
+    def test_defaults(self, publisher, memory_exporter):
+        with active_tracer().start_as_current_span("publish"):
+            publisher.publish("msg")
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+
+        attributes = spans[0].attributes
+        assert attributes["nameko.amqp.amqp_uri"] == nameko.config["AMQP_URI"]
+        assert attributes["nameko.amqp.use_confirms"] == "True"
+
+        # just check the other keys all exist
+        for attribute in (
+            "nameko.amqp.amqp_uri",
+            "nameko.amqp.ssl",
+            "nameko.amqp.use_confirms",
+            "nameko.amqp.delivery_mode",
+            "nameko.amqp.mandatory",
+            "nameko.amqp.priority",
+            "nameko.amqp.expiration",
+            "nameko.amqp.serializer",
+            "nameko.amqp.compression",
+            "nameko.amqp.retry",
+            "nameko.amqp.retry_policy",
+            "nameko.amqp.declarations",
+            "nameko.amqp.transport_options",
+            "nameko.amqp.publish_kwargs",
+        ):
+            assert attribute in attributes
+
+    def test_publish_time_overrides(self, publisher, memory_exporter):
+        with active_tracer().start_as_current_span("publish"):
+            publisher.publish("msg", use_confirms=False)
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+
+        attributes = spans[0].attributes
+        assert attributes["nameko.amqp.use_confirms"] == "False"
+
+    def test_routing_key_from_publisher(self, publisher, memory_exporter):
+        with active_tracer().start_as_current_span("publish"):
+            publisher.publish("msg")
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+
+        attributes = spans[0].attributes
+        assert attributes["nameko.amqp.routing_key"] == "foo"
+
+    def test_routing_key_from_publish_time(self, publisher, memory_exporter):
+        with active_tracer().start_as_current_span("publish"):
+            publisher.publish("msg", routing_key="bar")
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+
+        attributes = spans[0].attributes
+        assert attributes["nameko.amqp.routing_key"] == "bar"
+
+    def test_headers_from_publisher(self, publisher, memory_exporter):
+        with active_tracer().start_as_current_span("publish"):
+            publisher.publish("msg")
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+
+        attributes = spans[0].attributes
+        headers = ast.literal_eval(attributes["nameko.amqp.headers"])
+        assert headers == {
+            "header-1": "value-1",
+            "header-2": "value-2",
+            "header-3": "value-3",
+        }
+
+    def test_headers_from_publish_time(self, publisher, memory_exporter):
+        with active_tracer().start_as_current_span("publish"):
+            publisher.publish(
+                "msg", headers={"header-3": "REPLACED", "header-4": "value-4"}
+            )
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+
+        attributes = spans[0].attributes
+        headers = ast.literal_eval(attributes["nameko.amqp.headers"])
+        assert headers == {
+            "header-1": "value-1",
+            "header-2": "value-2",
+            "header-3": "REPLACED",
+            "header-4": "value-4",
+        }
+
+    def test_extra_headers_from_publish_time(self, publisher, memory_exporter):
+        with active_tracer().start_as_current_span("publish"):
+            publisher.publish(
+                "msg",
+                headers={"header-4": "value-4"},
+                extra_headers={"header-3": "REPLACED", "header-4": "REPLACED"},
+            )
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+
+        attributes = spans[0].attributes
+        headers = ast.literal_eval(attributes["nameko.amqp.headers"])
+        assert headers == {
+            "header-1": "value-1",
+            "header-2": "value-2",
+            "header-3": "REPLACED",
+            "header-4": "REPLACED",
+        }
+
+
+class TestSendHeaders:
+    @pytest.fixture
+    def publisher(self, rabbit_config):
+        return Publisher(amqp_uri=nameko.config["AMQP_URI"])
+
+    @pytest.fixture(params=[True, False], ids=["send_headers", "no_send_headers"])
+    def send_headers(self, request):
+        return request.param
+
+    @pytest.fixture
+    def config(self, config, send_headers):
+        config["send_headers"] = send_headers
+        return config
+
+    def test_send_headers_toggle(self, send_headers, publisher, memory_exporter):
+        with active_tracer().start_as_current_span("publish"):
+            publisher.publish("msg")
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+
+        attributes = spans[0].attributes
+        if send_headers:
+            assert "nameko.amqp.headers" in attributes
+        else:
+            assert "nameko.amqp.headers" not in attributes
+
+
+class TestConsumerAttributes:
+    @pytest.fixture
+    def consumer(self, rabbit_config):
+        return Consumer(nameko.config["AMQP_URI"])
+
+    def test_defaults(self, consumer):
+
+        attributes = amqp_consumer_attributes(consumer)
+        assert attributes["nameko.amqp.amqp_uri"] == nameko.config["AMQP_URI"]
+
+        # just check the other keys all exist
+        for attribute in (
+            "nameko.amqp.ssl",
+            "nameko.amqp.prefetch_count",
+            "nameko.amqp.heartbeat",
+            "nameko.amqp.accept",
+            "nameko.amqp.queues",
+            "nameko.amqp.consumer_options",
+        ):
+            assert attribute in attributes

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 import socket
-from unittest.mock import patch
+import uuid
+from unittest.mock import Mock, patch
 
 import pytest
-from nameko.rpc import rpc
-from nameko.testing.services import dummy, entrypoint_hook
+from nameko.rpc import ServiceRpc, rpc
+from nameko.standalone.rpc import ServiceRpcClient
+from nameko.testing.services import dummy, entrypoint_hook, entrypoint_waiter
+from nameko.testing.utils import get_extension
 from nameko.utils import REDACTED
 from opentelemetry import trace
+from opentelemetry.trace import SpanKind
 from opentelemetry.trace.status import StatusCode
 
 from nameko_opentelemetry.entrypoints import EntrypointAdapter
@@ -515,3 +519,81 @@ class TestPartialSpan:
 
         spans = memory_exporter.get_finished_spans()
         assert len(spans) == 0
+
+
+class TestScrubbing:
+    @pytest.fixture
+    def container(self, container_factory, rabbit_config):
+        class Service:
+            name = "service"
+
+            self_rpc = ServiceRpc("service")
+
+            @rpc
+            def method(self, arg, password=None):
+                return {"token": "should-be-secret"}
+
+        container = container_factory(Service)
+        container.start()
+
+        return container
+
+    @pytest.fixture(params=["standalone", "dependency_provider"])
+    def client(self, rabbit_config, request, container):
+
+        context_data = {
+            "call_id": f"service.method.{uuid.uuid4()}",
+            "token": "should-be-secret",
+        }
+
+        if request.param == "standalone":
+            with ServiceRpcClient("service", context_data=context_data) as client:
+                yield client
+        if request.param == "dependency_provider":
+            dp = get_extension(container, ServiceRpc)
+            yield dp.get_dependency(Mock(context_data=context_data))
+
+    def test_response_scrubber(self, container, client, memory_exporter):
+
+        with entrypoint_waiter(container, "method"):
+            assert client.method("arg", password="password") == {
+                "token": "should-be-secret"
+            }
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 2
+
+        server_span = list(filter(lambda span: span.kind == SpanKind.SERVER, spans))[0]
+
+        assert server_span.attributes["result"] == "{'token': 'scrubbed'}"
+
+    def test_call_args_scrubber(self, container, client, memory_exporter):
+
+        with entrypoint_waiter(container, "method"):
+            assert client.method("arg", password="password") == {
+                "token": "should-be-secret"
+            }
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 2
+
+        server_span = list(filter(lambda span: span.kind == SpanKind.SERVER, spans))[0]
+
+        assert (
+            server_span.attributes["call_args"]
+            == "{'arg': 'arg', 'password': 'scrubbed'}"
+        )
+
+    def test_context_data_scrubber(self, container, client, memory_exporter):
+
+        with entrypoint_waiter(container, "method"):
+            assert client.method("arg", password="password") == {
+                "token": "should-be-secret"
+            }
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 2
+
+        server_span = list(filter(lambda span: span.kind == SpanKind.SERVER, spans))[0]
+
+        assert "'token': 'scrubbed'" in server_span.attributes["context_data"]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -327,8 +327,7 @@ class TestScrubbing:
 
         # headers scrubbed at client
         assert (
-            client_span.attributes["nameko.amqp.headers"]
-            == f"{{'password': '{SCRUBBED}'}}"
+            f"'password': '{SCRUBBED}'" in client_span.attributes["nameko.amqp.headers"]
         )
         # context data scrubbed at server
         assert f"'password': '{SCRUBBED}'" in server_span.attributes["context_data"]

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -315,8 +315,8 @@ class TestScrubbing:
 
         # headers scrubbed at client
         assert (
-            client_span.attributes["nameko.amqp.headers"]
-            == f"{{'password': '{SCRUBBED}'}}"
+            f"'password': '{SCRUBBED}'" in client_span.attributes["nameko.amqp.headers"]
         )
+
         # context data scrubbed at server
         assert f"'password': '{SCRUBBED}'" in server_span.attributes["context_data"]

--- a/tests/test_scrubbers.py
+++ b/tests/test_scrubbers.py
@@ -14,6 +14,7 @@ class TestDefaultScubber:
         [
             "value",
             b"value",
+            b"\x90",
             1,
             1.0,
             True,

--- a/tests/test_scrubbers.py
+++ b/tests/test_scrubbers.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+import uuid
+from unittest.mock import Mock
+
+import pytest
+from nameko.rpc import ServiceRpc, rpc
+from nameko.standalone.rpc import ServiceRpcClient
+from nameko.testing.services import entrypoint_waiter
+from nameko.testing.utils import get_extension
+from opentelemetry.trace import SpanKind
+
+from nameko_opentelemetry.scrubbers import SCRUBBED, DefaultScrubber, scrub
+
+
+class TestDefaultScubber:
+    @pytest.fixture
+    def scrubber(self):
+        return DefaultScrubber(config={})
+
+    @pytest.mark.parametrize(
+        "value",
+        ["value", 1, 1.0, True, [1, 2, 3], dict(foo="bar"), (1, 2, 3), object()],
+    )
+    def test_innocuous(self, value, scrubber):
+        assert scrubber.scrub(value) == value
+
+    def test_sensitive_scalar(self, scrubber):
+        assert scrubber.scrub("matt@pacerevenue.com") == SCRUBBED
+
+    def test_list_with_sensitive_item(self, scrubber):
+        data = ["foo", "matt@pacerevenue.com", "bar"]
+        assert scrubber.scrub(data) == ["foo", SCRUBBED, "bar"]
+
+        # source data not modified
+        assert data == ["foo", "matt@pacerevenue.com", "bar"]
+
+    def test_tuple_with_sensitive_item(self, scrubber):
+        data = ("foo", "matt@pacerevenue.com", "bar")
+        assert scrubber.scrub(data) == ("foo", SCRUBBED, "bar")
+
+        # source data not modified
+        assert data == ("foo", "matt@pacerevenue.com", "bar")
+
+    def test_generator_with_sensitive_item(self, scrubber):
+        def items():
+            yield "foo"
+            yield "matt@pacerevenue.com"
+            yield "bar"
+
+        data = items()
+        assert scrubber.scrub(data) == ["foo", SCRUBBED, "bar"]
+
+    def test_dict_with_sensitive_key(self, scrubber):
+        data = {"password": "foobar"}
+        assert scrubber.scrub(data) == {"password": SCRUBBED}
+
+        # source data not modified
+        assert data == {"password": "foobar"}
+
+    def test_dict_with_sensitive_value(self, scrubber):
+        data = {"email": "matt@pacerevenue.com"}
+        assert scrubber.scrub(data) == {"email": SCRUBBED}
+
+        # source data not modified
+        assert data == {"email": "matt@pacerevenue.com"}
+
+    def test_dict_with_sensitive_value_for_key(self, scrubber):
+        data = {"matt@pacerevenue.com": "me"}
+        assert scrubber.scrub(data) == {SCRUBBED: "me"}
+
+        # source data not modified
+        assert data == {"matt@pacerevenue.com": "me"}
+
+    def test_dict_with_sensitive_sub_key(self, scrubber):
+        data = {"innocuous": {"email": "matt@pacerevenue.com"}}
+        assert scrubber.scrub(data) == {"innocuous": {"email": SCRUBBED}}
+
+        # source data not modified
+        assert data == {"innocuous": {"email": "matt@pacerevenue.com"}}
+
+    def test_dict_with_nested_list_containing_sensitive_value(self, scrubber):
+        data = {"innocuous": ["foo", "matt@pacerevenue.com", "bar"]}
+        assert scrubber.scrub(data) == {"innocuous": ["foo", SCRUBBED, "bar"]}
+
+        # source data not modified
+        assert data == {"innocuous": ["foo", "matt@pacerevenue.com", "bar"]}
+
+    def test_list_with_nested_dict_containing_sensitive_data(self, scrubber):
+        data = ["foo", {"email": "matt@pacerevenue.com", "secret": "shh"}, "bar"]
+        assert scrubber.scrub(data) == [
+            "foo",
+            {"email": SCRUBBED, "secret": SCRUBBED},
+            "bar",
+        ]
+
+        # source data not modified
+        assert data == [
+            "foo",
+            {"email": "matt@pacerevenue.com", "secret": "shh"},
+            "bar",
+        ]
+
+
+class CustomScrubber(DefaultScrubber):
+    SENSITIVE_KEYS = ("name",)
+    REPLACEMENT = "***"
+
+
+class TestScrub:
+    @pytest.fixture
+    def config(self):
+        return {
+            "scrubbers": (
+                "test_scrubbers.CustomScrubber",
+                "nameko_opentelemetry.scrubbers.DefaultScrubber",
+            )
+        }
+
+    def test_register_new_scrubber(self, config):
+        data = {"name": "Matt", "email": "matt@pacerevenue.com"}
+        assert scrub(data, config) == {"name": "***", "email": "***"}
+
+
+class XTestScrubbers:
+    @pytest.fixture
+    def container(self, container_factory, rabbit_config):
+        class Service:
+            name = "service"
+
+            self_rpc = ServiceRpc("service")
+
+            @rpc
+            def method(self, arg, password=None):
+                return {"token": "should-be-secret"}
+
+        container = container_factory(Service)
+        container.start()
+
+        return container
+
+    @pytest.fixture(params=["standalone", "dependency_provider"])
+    def client(self, rabbit_config, request, container):
+
+        context_data = {
+            "call_id": f"service.method.{uuid.uuid4()}",
+            "token": "should-be-secret",
+        }
+
+        if request.param == "standalone":
+            with ServiceRpcClient("service", context_data=context_data) as client:
+                yield client
+        if request.param == "dependency_provider":
+            dp = get_extension(container, ServiceRpc)
+            yield dp.get_dependency(Mock(context_data=context_data))
+
+    def test_response_scrubber(self, container, client, memory_exporter):
+
+        with entrypoint_waiter(container, "method"):
+            assert client.method("arg", password="password") == {
+                "token": "should-be-secret"
+            }
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 2
+
+        server_span = list(filter(lambda span: span.kind == SpanKind.SERVER, spans))[0]
+
+        assert server_span.attributes["result"] == '{"token": "scrubbed"}'
+
+    def test_call_args_scrubber(self, container, client, memory_exporter):
+
+        with entrypoint_waiter(container, "method"):
+            assert client.method("arg", password="password") == {
+                "token": "should-be-secret"
+            }
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 2
+
+        client_span = list(filter(lambda span: span.kind == SpanKind.CLIENT, spans))[0]
+        server_span = list(filter(lambda span: span.kind == SpanKind.SERVER, spans))[0]
+
+        assert (
+            client_span.attributes["call_args"]
+            == '{"arg": "arg", "password": "scrubbed"}'
+        )
+        assert server_span.attributes["result"] == '{"token": "scrubbed"}'
+
+    def test_context_data_scrubber(self, container, client, memory_exporter):
+
+        with entrypoint_waiter(container, "method"):
+            assert client.method("arg", password="password") == {
+                "token": "should-be-secret"
+            }
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 2
+
+        client_span = list(filter(lambda span: span.kind == SpanKind.CLIENT, spans))[0]
+        server_span = list(filter(lambda span: span.kind == SpanKind.SERVER, spans))[0]
+
+        assert '"token": "scrubbed"' in client_span.attributes.context_data
+        assert '"token": "scrubbed"' in server_span.attributes.context_data

--- a/tests/test_scrubbers.py
+++ b/tests/test_scrubbers.py
@@ -11,13 +11,26 @@ class TestDefaultScubber:
 
     @pytest.mark.parametrize(
         "value",
-        ["value", 1, 1.0, True, [1, 2, 3], dict(foo="bar"), (1, 2, 3), object()],
+        [
+            "value",
+            b"value",
+            1,
+            1.0,
+            True,
+            [1, 2, 3],
+            dict(foo="bar"),
+            (1, 2, 3),
+            object(),
+        ],
     )
     def test_innocuous(self, value, scrubber):
         assert scrubber.scrub(value) == value
 
-    def test_sensitive_scalar(self, scrubber):
+    def test_sensitive_string(self, scrubber):
         assert scrubber.scrub("matt@pacerevenue.com") == SCRUBBED
+
+    def test_sensitive_bytes(self, scrubber):
+        assert scrubber.scrub(b"matt@pacerevenue.com") == SCRUBBED.encode("utf-8")
 
     def test_list_with_sensitive_item(self, scrubber):
         data = ["foo", "matt@pacerevenue.com", "bar"]


### PR DESCRIPTION
Adds support for scrubbing values.

Scrubbing is applied to all headers, context data, request and response payloads, and all entrypoint call args and return values.

The default implementation expects to be passed a dictionary, other iterable, or scalar. Values are scrubbed if they match any of the list of [regexes provided here](https://github.com/nameko/opentelemetry-instrumentation-nameko/blob/ff8a452b88f2ced3e14f52829b4ab264686e3fe8/nameko_opentelemetry/scrubbers.py#L46-L48), or if they are keyed in a dictionary by a key that matches [a sensitive key name](https://github.com/nameko/opentelemetry-instrumentation-nameko/blob/ff8a452b88f2ced3e14f52829b4ab264686e3fe8/nameko_opentelemetry/scrubbers.py#L27-L42), with or without certain [common prefixes](https://github.com/nameko/opentelemetry-instrumentation-nameko/blob/ff8a452b88f2ced3e14f52829b4ab264686e3fe8/nameko_opentelemetry/scrubbers.py#L44).

Example:

``` python
>>> scrub({
    "foobar": "nameko@example.com",
    "token": "abc",
    "things": {
        "password": "secret"
        "favourites": ["red", "white", "blue"]
}, config)
... {
    "foobar": "scrubbed",
    "token": "scrubbed",
    "things": {
        "password": "scrubbed"
        "favourites": ["red", "white", "blue"]
    }
```

You can define a custom scrubber like so:

``` python
class Scrubber(DefaultScrubber):
    SENSITIVE_KEYS=(
        "supersecret"
    )
    COMMON_KEY_PREFIXES = (...)
    SENSITIVE_VALUES = (
        r"^matt$"
    )
    REPLACEMENT = "*****"
    
    def sensitive_value(self, value):
        # do something other than compare to all the regexes, e.g. try to json decode first
        return super().sensitive_value(value)
```

After defining a custom scrubber you can pass it to the instrumentation like so:

``` python
from nameko_opentelemetry import NamekoInstrumentor
NamekoInstrumentor().instrument(
    # adds a new custom scrubber, keeping the default as well
    scrubbers=["my.custom.Scrubber", "nameko_opentelemetry.scrubbers.DefaultScrubber"] 
)
```



