### PR TITLE
make sure wrapped methods are actually called

### DIFF
--- a/nameko_opentelemetry/entrypoints.py
+++ b/nameko_opentelemetry/entrypoints.py
@@ -232,6 +232,8 @@ def worker_setup(tracer, config, wrapped, instance, args, kwargs):
 
     adapter.start_span(span)
 
+    wrapped(*args, **kwargs)
+
 
 def worker_result(tracer, config, wrapped, instance, args, kwargs):
     """ Wrap nameko.containers.ServiceContainer._worker_result.
@@ -259,6 +261,8 @@ def worker_result(tracer, config, wrapped, instance, args, kwargs):
     span.end(_time_ns())
     context.detach(token)
 
+    wrapped(*args, **kwargs)
+
 
 def instrument(tracer, config):
 
@@ -285,5 +289,5 @@ def instrument(tracer, config):
 
 
 def uninstrument():
-    unwrap(nameko.containers.ServiceContainer, "worker_setup")
-    unwrap(nameko.containers.ServiceContainer, "worker_result")
+    unwrap(nameko.containers.ServiceContainer, "_worker_setup")
+    unwrap(nameko.containers.ServiceContainer, "_worker_result")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,36 @@
 # -*- coding: utf-8 -*-
 import pytest
 from opentelemetry import trace
+from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from wrapt import wrap_function_wrapper
 
 from nameko_opentelemetry import NamekoInstrumentor
 
 
 @pytest.fixture(scope="session")
-def memory_exporter():
+def filter_spans():
+    def filter_rabbit(span):
+        if "api/vhosts/nameko_test" not in span.attributes.get("http.url", ""):
+            return True
+
+    def get_finished_spans(wrapped, instance, args, kwargs):
+        spans = wrapped(*args, **kwargs)
+        return list(filter(filter_rabbit, spans))
+
+    wrap_function_wrapper(
+        "opentelemetry.sdk.trace.export.in_memory_span_exporter",
+        "InMemorySpanExporter.get_finished_spans",
+        get_finished_spans,
+    )
+    yield
+    unwrap(InMemorySpanExporter, "get_finished_spans")
+
+
+@pytest.fixture(scope="session")
+def memory_exporter(filter_spans):
     return InMemorySpanExporter()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,9 @@ from nameko_opentelemetry import NamekoInstrumentor
 @pytest.fixture(scope="session")
 def filter_spans():
     def filter_rabbit(span):
-        if "api/vhosts/nameko_test" not in span.attributes.get("http.url", ""):
+        if "api/vhosts/nameko_test" not in span.attributes.get(
+            "http.url", ""
+        ):  # pragma: no cover (don't cover false branch)
             return True
 
     def get_finished_spans(wrapped, instance, args, kwargs):


### PR DESCRIPTION
The functions that wrapped the worker setup and result methods on the service container never actually called the underlying methods 🙈 

Also:

* fixes a silly typo that leaked patches between tests, which somehow didn't cause problems before.
* filters out spans captured as the rabbitmq ghost used in previously-run tests is removed, which occasionally caused flakiness in subsequent tests 
