### PR TITLE
Fix memory leak

### DIFF
--- a/nameko_opentelemetry/entrypoints.py
+++ b/nameko_opentelemetry/entrypoints.py
@@ -244,7 +244,7 @@ def worker_result(tracer, config, wrapped, instance, args, kwargs):
     """
     (worker_ctx, result, exc_info) = args
 
-    activated = active_spans.get(worker_ctx)
+    activated = active_spans.pop(worker_ctx, None)
     if not activated:
         # something went wrong when starting the span; nothing more to do
         warnings.warn("worker result when no active span")

--- a/nameko_opentelemetry/entrypoints.py
+++ b/nameko_opentelemetry/entrypoints.py
@@ -64,78 +64,79 @@ class EntrypointAdapter:
 
     span_kind = trace.SpanKind.SERVER
 
-    def __init__(self, worker_ctx, config):
-        self.worker_ctx = worker_ctx
+    def __init__(self, config):
         self.config = config
 
-    def get_span_name(self):
-        return (
-            f"{self.worker_ctx.service_name}.{self.worker_ctx.entrypoint.method_name}"
-        )
+    def get_span_name(self, worker_ctx):
+        return f"{worker_ctx.service_name}.{worker_ctx.entrypoint.method_name}"
 
-    def get_metadata(self):
-        return self.worker_ctx.context_data
+    def get_metadata(self, worker_ctx):
+        return worker_ctx.context_data
 
-    def exception_was_expected(self, exc):
+    def exception_was_expected(self, worker_ctx, exc):
         expected_exceptions = getattr(
-            self.worker_ctx.entrypoint, "expected_exceptions", None
+            worker_ctx.entrypoint, "expected_exceptions", None
         )
         expected_exceptions = expected_exceptions or tuple()
         return isinstance(exc, expected_exceptions)
 
-    def start_span(self, span):
+    def start_span(self, span, worker_ctx):
         if span.is_recording():
-            span.set_attributes(self.get_attributes())
+            span.set_attributes(self.get_attributes(worker_ctx))
 
-    def end_span(self, span, result, exc_info):
+    def end_span(self, span, worker_ctx, result, exc_info):
         if span.is_recording():
 
             if exc_info:
                 span.record_exception(
                     exc_info[1],
                     escaped=True,
-                    attributes=self.get_exception_attributes(exc_info),
+                    attributes=self.get_exception_attributes(worker_ctx, exc_info),
                 )
             else:
-                span.set_attributes(self.get_result_attributes(result) or {})
+                span.set_attributes(
+                    self.get_result_attributes(worker_ctx, result) or {}
+                )
 
-            status = self.get_status(result, exc_info)
+            status = self.get_status(worker_ctx, result, exc_info)
             span.set_status(status)
 
-    def get_attributes(self):
+    def get_attributes(self, worker_ctx):
         """ Common attributes for most entrypoints, and hooks into subclassable
         implementations to fetch optional attributes.
         """
-        entrypoint = self.worker_ctx.entrypoint
+        entrypoint = worker_ctx.entrypoint
 
         attributes = {
-            "service_name": self.worker_ctx.service_name,
+            "service_name": worker_ctx.service_name,
             "entrypoint_type": type(entrypoint).__name__,
             "method_name": entrypoint.method_name,
-            "active_workers": self.worker_ctx.container._worker_pool.running(),
-            "available_workers": self.worker_ctx.container._worker_pool.free(),
+            "active_workers": worker_ctx.container._worker_pool.running(),
+            "available_workers": worker_ctx.container._worker_pool.free(),
         }
 
-        attributes.update(self.get_header_attributes() or {})
+        attributes.update(self.get_header_attributes(worker_ctx) or {})
 
         if getattr(entrypoint, "sensitive_arguments", None):
             call_args = get_redacted_args(
-                entrypoint, *self.worker_ctx.args, **self.worker_ctx.kwargs
+                entrypoint, *worker_ctx.args, **worker_ctx.kwargs
             )
             redacted = True
         else:
             method = getattr(entrypoint.container.service_cls, entrypoint.method_name)
             call_args = inspect.getcallargs(
-                method, None, *self.worker_ctx.args, **self.worker_ctx.kwargs
+                method, None, *worker_ctx.args, **worker_ctx.kwargs
             )
             del call_args["self"]
             redacted = False
 
-        attributes.update(self.get_call_args_attributes(call_args, redacted) or {})
+        attributes.update(
+            self.get_call_args_attributes(worker_ctx, call_args, redacted) or {}
+        )
 
         return attributes
 
-    def get_call_args_attributes(self, call_args, redacted):
+    def get_call_args_attributes(self, worker_ctx, call_args, redacted):
         """ ...
         """
         if self.config.get("send_request_payloads"):
@@ -150,17 +151,17 @@ class EntrypointAdapter:
                 "call_args_redacted": str(redacted),
             }
 
-    def get_header_attributes(self):
+    def get_header_attributes(self, worker_ctx):
         """ ...
         """
         if self.config.get("send_headers"):
             return {
                 "context_data": utils.serialise_to_string(
-                    scrub(self.worker_ctx.data, self.config)
+                    scrub(worker_ctx.data, self.config)
                 )
             }
 
-    def get_exception_attributes(self, exc_info):
+    def get_exception_attributes(self, worker_ctx, exc_info):
         """ Additional attributes to save alongside a worker exception.
         """
         exc_type, exc, _ = exc_info
@@ -172,10 +173,10 @@ class EntrypointAdapter:
 
         return {
             "exception.stacktrace": stacktrace,
-            "exception.expected": str(self.exception_was_expected(exc)),
+            "exception.expected": str(self.exception_was_expected(worker_ctx, exc)),
         }
 
-    def get_result_attributes(self, result):
+    def get_result_attributes(self, worker_ctx, result):
         """ Attributes describing the entrypoint method result.
         """
         if self.config.get("send_response_payloads"):
@@ -183,13 +184,13 @@ class EntrypointAdapter:
                 "result": utils.serialise_to_string(scrub(result or "", self.config))
             }
 
-    def get_status(self, result, exc_info):
+    def get_status(self, worker_ctx, result, exc_info):
         """ Span status for this worker.
         """
         if exc_info:
             exc_type, exc, _ = exc_info
 
-            if not self.exception_was_expected(exc):
+            if not self.exception_was_expected(worker_ctx, exc):
                 return Status(
                     StatusCode.ERROR,
                     description="{}: {}".format(type(exc).__name__, exc),
@@ -200,7 +201,7 @@ class EntrypointAdapter:
 
 def adapter_factory(worker_ctx, config):
     adapter_class = adapter_types[type(worker_ctx.entrypoint)]
-    return adapter_class(worker_ctx, config)
+    return adapter_class(config)
 
 
 def worker_setup(tracer, config, wrapped, instance, args, kwargs):
@@ -213,11 +214,11 @@ def worker_setup(tracer, config, wrapped, instance, args, kwargs):
     (worker_ctx,) = args
 
     adapter = adapter_factory(worker_ctx, config)
-    ctx = extract(adapter.get_metadata())
+    ctx = extract(adapter.get_metadata(worker_ctx))
     token = context.attach(ctx)
 
     span = tracer.start_span(
-        adapter.get_span_name(),
+        adapter.get_span_name(worker_ctx),
         kind=adapter.span_kind,
         attributes={"hostname": socket.gethostname()},
         start_time=_time_ns(),
@@ -230,7 +231,7 @@ def worker_setup(tracer, config, wrapped, instance, args, kwargs):
     activation.__enter__()
     active_spans[worker_ctx] = (activation, span, token, adapter)
 
-    adapter.start_span(span)
+    adapter.start_span(span, worker_ctx)
 
     wrapped(*args, **kwargs)
 
@@ -251,7 +252,7 @@ def worker_result(tracer, config, wrapped, instance, args, kwargs):
 
     activation, span, token, adapter = activated
 
-    adapter.end_span(span, result, exc_info)
+    adapter.end_span(span, worker_ctx, result, exc_info)
 
     if exc_info is None:
         activation.__exit__(None, None, None)

--- a/nameko_opentelemetry/events.py
+++ b/nameko_opentelemetry/events.py
@@ -30,12 +30,12 @@ class EventHandlerEntrypointAdapter(EntrypointAdapter):
 
     span_kind = trace.SpanKind.CONSUMER
 
-    def get_attributes(self):
+    def get_attributes(self, worker_ctx):
         """ Include configuration of the entrypoint, and AMQP consumer attributes.
         """
-        attrs = super().get_attributes()
+        attrs = super().get_attributes(worker_ctx)
 
-        entrypoint = self.worker_ctx.entrypoint
+        entrypoint = worker_ctx.entrypoint
 
         attrs.update(
             {
@@ -45,7 +45,7 @@ class EventHandlerEntrypointAdapter(EntrypointAdapter):
             }
         )
 
-        consumer = self.worker_ctx.entrypoint.consumer
+        consumer = worker_ctx.entrypoint.consumer
         attrs.update(amqp_consumer_attributes(consumer))
         return attrs
 

--- a/nameko_opentelemetry/messaging.py
+++ b/nameko_opentelemetry/messaging.py
@@ -24,18 +24,18 @@ class ConsumerEntrypointAdapter(EntrypointAdapter):
 
     span_kind = trace.SpanKind.CONSUMER
 
-    def get_attributes(self):
+    def get_attributes(self, worker_ctx):
         """ Include configuration of the entrypoint, and AMQP consumer attributes.
         """
-        attrs = super().get_attributes()
+        attrs = super().get_attributes(worker_ctx)
 
-        entrypoint = self.worker_ctx.entrypoint
+        entrypoint = worker_ctx.entrypoint
 
         attrs.update(
             {"nameko.messaging.requeue_on_error": str(entrypoint.requeue_on_error)}
         )
 
-        consumer = self.worker_ctx.entrypoint.consumer
+        consumer = worker_ctx.entrypoint.consumer
         attrs.update(amqp_consumer_attributes(consumer))
         return attrs
 

--- a/nameko_opentelemetry/rpc.py
+++ b/nameko_opentelemetry/rpc.py
@@ -31,12 +31,12 @@ class RpcEntrypointAdapter(EntrypointAdapter):
     """ Adapter customisation for RPC entrypoints.
     """
 
-    def get_attributes(self):
+    def get_attributes(self, worker_ctx):
         """ Include AMQP consumer attributes
         """
-        attributes = super().get_attributes()
+        attributes = super().get_attributes(worker_ctx)
 
-        consumer = self.worker_ctx.entrypoint.rpc_consumer.consumer
+        consumer = worker_ctx.entrypoint.rpc_consumer.consumer
         attributes.update(amqp_consumer_attributes(consumer))
         return attributes
 

--- a/nameko_opentelemetry/timer.py
+++ b/nameko_opentelemetry/timer.py
@@ -6,13 +6,13 @@ class TimerEntrypointAdapter(EntrypointAdapter):
     """ Adapter customisation for Timer entrypoints.
     """
 
-    def get_attributes(self):
-        attrs = super().get_attributes()
+    def get_attributes(self, worker_ctx):
+        attrs = super().get_attributes(worker_ctx)
 
         attrs.update(
             {
-                "nameko.timer.interval": self.worker_ctx.entrypoint.interval,
-                "nameko.timer.eager": self.worker_ctx.entrypoint.eager,
+                "nameko.timer.interval": worker_ctx.entrypoint.interval,
+                "nameko.timer.eager": worker_ctx.entrypoint.eager,
             }
         )
         return attrs

--- a/nameko_opentelemetry/version.py
+++ b/nameko_opentelemetry/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     url="https://github.com/nameko/opentelemetry-instrumentation-nameko",
     packages=find_packages(exclude=["test", "test.*"]),
     install_requires=[
-        "nameko==3.0.0rc9",
+        "nameko>=3.0.0rc9",
         "opentelemetry-api",
         "opentelemetry-instrumentation",
         "opentelemetry-instrumentation-wsgi",

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -556,7 +556,7 @@ class TestPartialSpan:
     def test_span_not_started(self, active_spans, container, memory_exporter):
 
         # fake a missing span
-        active_spans.get.return_value = None
+        active_spans.pop.return_value = None
 
         with pytest.warns(UserWarning) as warnings:
             with entrypoint_hook(container, "method") as hook:

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -147,7 +147,7 @@ class TestNoTracer:
 
 
 class CustomAdapter(EntrypointAdapter):
-    def get_span_name(self):
+    def get_span_name(self, worker_ctx):
         return "custom_span_name"
 
 


### PR DESCRIPTION
Instrumented services leaked memory because the `active_spans` weak key dictionary in `nameko_opentelemetry.entrypoints` accumulated items.

`active_spans` is keyed by worker context, and the _values_ stored in this dict included the entrypoint adapter, which in turn held a reference to the worker context -- hence the references to the worker context never went to zero and the items remained in the dictionary.

In this PR:

* We always remove the item from the dict when finishing the span, rather than relying on weak keys.
* The circular reference is removed by passing `worker_ctx` around rather than stashing it on the adapter. This means the key will be removed when the worker context goes out of scope, even if the span is never finished for some reason.
