### PR TITLE
Iterable dict keys serialization fix

### DIFF
--- a/nameko_opentelemetry/utils.py
+++ b/nameko_opentelemetry/utils.py
@@ -37,7 +37,7 @@ def safe_for_serialisation(value):
             for key, val in six.iteritems(value)
         }
     if isinstance(value, collections.abc.Iterable):
-        return list(map(safe_for_serialisation, value))
+        return type(value)(map(safe_for_serialisation, value))
     try:
         return six.text_type(value)
     except Exception:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,24 +9,24 @@ from nameko_opentelemetry import utils
     (
         ("string", "string"),
         ([1, 0.5, "string"], [1, 0.5, "string"]),
-        ((1, 0.5, "string"), [1, 0.5, "string"]),
+        ((1, 0.5, "string"), (1, 0.5, "string")),
         ({1: 2, 0.5: 0.5}, {1: 2, 0.5: 0.5}),
         ({"string": "string"}, {"string": "string"}),
         ({(1, 2, 3): "string"}, {(1, 2, 3): "string"}),
-        ({1}, [1]),
+        ({1}, {1}),
         (object, repr(object)),
         (None, None),
         (
             ((1, 0.5, "string", object), [], {}, set()),
-            [[1, 0.5, "string", repr(object)], [], {}, []],
+            ((1, 0.5, "string", repr(object)), [], {}, set()),
         ),
         (
             ((), [1, 0.5, "string", object], {}),
-            [[], [1, 0.5, "string", repr(object)], {}],
+            ((), [1, 0.5, "string", repr(object)], {}),
         ),
         (
             ((), [], {1: {0.5: ("string", object)}}),
-            [[], [], {1: {0.5: ["string", repr(object)]}}],
+            ((), [], {1: {0.5: ("string", repr(object))}}),
         ),
         (b"bytes to decode", "bytes to decode"),
     ),
@@ -57,7 +57,7 @@ def test_serialise_to_json():
 def test_serialise_to_string():
     assert (
         utils.serialise_to_string(((), [], {1: {0.5: ("string", object)}}))
-        == "[[], [], {1: {0.5: ['string', \"<class 'object'>\"]}}]"
+        == "((), [], {1: {0.5: ('string', \"<class 'object'>\")}})"
     )
 
 


### PR DESCRIPTION
Fixes a bug in `safe_for_serialisation`. Feeding in a dict with iterable keys would result in an "unhashable type" error because the iterable was always converted to a list.

Instead we maintain the original type of the iterable, meaning that any iterable suitable for use as a dict key can remain as that dict key.

