### PR TITLE
Truncate response payload

### DIFF
--- a/nameko_opentelemetry/entrypoints.py
+++ b/nameko_opentelemetry/entrypoints.py
@@ -176,8 +176,14 @@ class EntrypointAdapter:
     def get_result_attributes(self, worker_ctx, result):
         """Attributes describing the entrypoint method result."""
         if self.config.get("send_response_payloads"):
+            result, truncated = utils.truncate(
+                utils.serialise_to_string(scrub(result or "", self.config)),
+                max_len=self.config.get("truncate_max_length"),
+            )
+
             return {
-                "result": utils.serialise_to_string(scrub(result or "", self.config))
+                "result": result,
+                "result_truncated": str(truncated),
             }
 
     def get_status(self, worker_ctx, result, exc_info):

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -250,6 +250,7 @@ class TestResultAttributes:
             assert attributes["result_truncated"] == "False"
         else:
             assert "result" not in attributes
+            assert "result_truncated" not in attributes
 
     def test_response_truncated(self, container, memory_exporter, send_response_payloads):
         with entrypoint_hook(container, "method_truncated") as hook:
@@ -266,6 +267,7 @@ class TestResultAttributes:
             assert attributes["result_truncated"] == "True"
         else:
             assert "result" not in attributes
+            assert "result_truncated" not in attributes
 
     def test_exception(self, container, memory_exporter, send_response_payloads):
 
@@ -283,6 +285,7 @@ class TestResultAttributes:
             assert attributes.get("result") is None
         else:
             assert "result" not in attributes
+            assert "result_truncated" not in attributes
 
     def test_unserializable_result(
         self, container, memory_exporter, unserializable_object, send_response_payloads
@@ -301,6 +304,7 @@ class TestResultAttributes:
             assert attributes["result"] == str(unserializable_object)
         else:
             assert "result" not in attributes
+            assert "result_truncated" not in attributes
 
 
 class TestExceptions:

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -197,6 +197,8 @@ class TestResultAttributes:
     def config(self, config, send_response_payloads):
         # disable headers based on param
         config["send_response_payloads"] = send_response_payloads
+        # override default truncation length
+        config["truncate_max_length"] = 200
         return config
 
     @pytest.fixture
@@ -214,6 +216,10 @@ class TestResultAttributes:
             @rpc
             def method(self, arg, kwarg=None):
                 return "OK"
+
+            @rpc
+            def method_truncated(self, arg, kwarg=None):
+                return "OK" * 1000
 
             @dummy
             def unserializable(self, arg, kwarg=None):
@@ -241,6 +247,23 @@ class TestResultAttributes:
 
         if send_response_payloads:
             assert attributes["result"] == "OK"
+            assert attributes["result_truncated"] == "False"
+        else:
+            assert "result" not in attributes
+
+    def test_response_truncated(self, container, memory_exporter, send_response_payloads):
+        with entrypoint_hook(container, "method_truncated") as hook:
+            assert hook("arg", kwarg="kwarg") == "OK" * 1000
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+
+        attributes = spans[0].attributes
+        assert attributes["method_name"] == "method_truncated"
+
+        if send_response_payloads:
+            assert attributes["result"] == "OK" * 100
+            assert attributes["result_truncated"] == "True"
         else:
             assert "result" not in attributes
 

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -265,7 +265,7 @@ class TestResultAttributes:
         assert attributes["method_name"] == "method_truncated"
 
         if send_response_payloads:
-            assert attributes["result"] == "OK" * 100
+            assert len(attributes["result"]) == 200
             assert attributes["result_truncated"] == "True"
         else:
             assert "result" not in attributes

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -252,7 +252,9 @@ class TestResultAttributes:
             assert "result" not in attributes
             assert "result_truncated" not in attributes
 
-    def test_response_truncated(self, container, memory_exporter, send_response_payloads):
+    def test_response_truncated(
+        self, container, memory_exporter, send_response_payloads
+    ):
         with entrypoint_hook(container, "method_truncated") as hook:
             assert hook("arg", kwarg="kwarg") == "OK" * 1000
 


### PR DESCRIPTION
This is truncating response payload to ensure no spans gets thrown away for having a payload too big.
We already truncate request payload.