### PR TITLE
pin importlib for earlier versions of python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
   - id: fix-encoding-pragma
   - id: flake8
 - repo: https://github.com/pycqa/isort
-  rev: 5.6.3
+  rev: 5.12.0
   hooks:
   - id: isort
 - repo: https://github.com/ambv/black

--- a/nameko_opentelemetry/version.py
+++ b/nameko_opentelemetry/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,7 @@ setup(
         "opentelemetry-api",
         "opentelemetry-instrumentation",
         "opentelemetry-instrumentation-wsgi",
-        "importlib-metadata<=4.13.0",  # Temporary pin,
-        # remove when https://github.com/celery/kombu/pull/1601
-        # is in the most recent version of kombu
+        "importlib-metadata<5 ; python_version<='3.7'",
     ],
     extras_require={
         "dev": list(PACKAGE_INFO["_instruments"])

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
             "coverage",
             "pytest",
             "opentelemetry-sdk",
-            "opentelemetry-instrumentation-requests",
+            "opentelemetry-instrumentation-requests>=0.39b0",
         ],
         "instruments": PACKAGE_INFO["_instruments"],
     },

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
             "coverage",
             "pytest",
             "opentelemetry-sdk",
-            "opentelemetry-instrumentation-requests>=0.39b0",
+            "opentelemetry-instrumentation-requests",
         ],
         "instruments": PACKAGE_INFO["_instruments"],
     },

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -89,7 +89,7 @@ class TestSpanName:
         spans = memory_exporter.get_finished_spans()
         assert len(spans) == 1
 
-        assert spans[0].name == "GET /missing"
+        assert "GET" in spans[0].name
 
 
 class TestNoEntrypointFired:
@@ -121,7 +121,7 @@ class TestNoEntrypointFired:
 
         span = spans[0]
 
-        assert spans[0].name == "GET /missing"
+        assert "GET" in spans[0].name
 
         assert not span.status.is_ok
         assert span.status.status_code == StatusCode.ERROR
@@ -139,7 +139,7 @@ class TestNoEntrypointFired:
 
         span = spans[0]
 
-        assert spans[0].name == "POST /resource"
+        assert "POST" in spans[0].name
 
         assert not span.status.is_ok
         assert span.status.status_code == StatusCode.ERROR

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -89,7 +89,7 @@ class TestSpanName:
         spans = memory_exporter.get_finished_spans()
         assert len(spans) == 1
 
-        assert spans[0].name == "HTTP GET"
+        assert spans[0].name == "GET /missing"
 
 
 class TestNoEntrypointFired:
@@ -121,7 +121,7 @@ class TestNoEntrypointFired:
 
         span = spans[0]
 
-        assert spans[0].name == "HTTP GET"
+        assert spans[0].name == "GET /missing"
 
         assert not span.status.is_ok
         assert span.status.status_code == StatusCode.ERROR
@@ -139,7 +139,7 @@ class TestNoEntrypointFired:
 
         span = spans[0]
 
-        assert spans[0].name == "HTTP POST"
+        assert spans[0].name == "POST /resource"
 
         assert not span.status.is_ok
         assert span.status.status_code == StatusCode.ERROR


### PR DESCRIPTION
Newer version of requests instrumentation changed span names to meet the otel spec. I've updated tests to work with both versions by making the asserts a bit more lenient.